### PR TITLE
Error fixes and name changes

### DIFF
--- a/src/epub/text/book-12.xhtml
+++ b/src/epub/text/book-12.xhtml
@@ -565,7 +565,7 @@
 				<br/>
 				<span>The rock, lest where it juts into the sea</span>
 				<br/>
-				<span>Thou heed it not, and bring us ail to wreck.’</span>
+				<span>Thou heed it not, and bring us all to wreck.’</span>
 			</p>
 			<p>
 				<span>“I spake, and quickly all obeyed my words.</span>

--- a/src/epub/text/book-4.xhtml
+++ b/src/epub/text/book-4.xhtml
@@ -892,7 +892,7 @@
 				<br/>
 				<span>Through tenderness to me, or kind regard,</span>
 				<br/>
-				<span>But tell me plainly ail that thou dost know;</span>
+				<span>But tell me plainly all that thou dost know;</span>
 				<br/>
 				<span>And I beseech thee, if at any time</span>
 				<br/>
@@ -1314,7 +1314,7 @@
 				<br/>
 				<span>Untimely in their ships or in the arms</span>
 				<br/>
-				<span>Of their companions since the war wasclosed?’</span>
+				<span>Of their companions since the war was closed?’</span>
 			</p>
 			<p>
 				<span>“I spake; again he answered me and said:⁠—</span>

--- a/src/epub/text/book-4.xhtml
+++ b/src/epub/text/book-4.xhtml
@@ -994,7 +994,7 @@
 				<br/>
 				<span>Had not a goddess pitied me, and come</span>
 				<br/>
-				<span>To my relief, by name Idothea, born</span>
+				<span>To my relief, by name Eidothea, born</span>
 				<br/>
 				<span>To the great Proteus, Ancient of the Deep.</span>
 				<br/>
@@ -2112,7 +2112,7 @@
 				<br/>
 				<span>A phantom up, in aspect like the dame</span>
 				<br/>
-				<span>Iphthima, whom Eumelus had espoused</span>
+				<span>Iphthime, whom Eumelus had espoused</span>
 				<br/>
 				<span>In Pherae, daughter of the high-souled chief</span>
 				<br/>

--- a/src/epub/text/book-5.xhtml
+++ b/src/epub/text/book-5.xhtml
@@ -15,7 +15,7 @@
 					</h2>
 					<h3 epub:type="title">Departure of Ulysses from Calypso</h3>
 				</hgroup>
-				<p epub:type="bridgehead">Mercury despatched by Jupiter to Calypso with a message commanding her to send away Ulysses⁠—A raft contructed by Ulysses⁠—His departure on the raft⁠—A storm raised by Neptune, and the raft destroyed⁠—Escape of Ulysses from the tempest, and his landing on the isle of Scheria, inhabited by the Phaeacians.</p>
+				<p epub:type="bridgehead">Mercury despatched by Jupiter to Calypso with a message commanding her to send away Ulysses⁠—A raft constructed by Ulysses⁠—His departure on the raft⁠—A storm raised by Neptune, and the raft destroyed⁠—Escape of Ulysses from the tempest, and his landing on the isle of Scheria, inhabited by the Phaeacians.</p>
 			</header>
 			<p>
 				<span>Aurora, rising from her couch beside</span>
@@ -910,7 +910,7 @@
 				<br/>
 				<span>’Tis said my refuge lies. This will I do,</span>
 				<br/>
-				<span>For this seems wisest While the fastenings last</span>
+				<span>For this seems wisest. While the fastenings last</span>
 				<br/>
 				<span>That hold these timbers, I will keep my place</span>
 				<br/>


### PR DESCRIPTION
Name changes:
- Iphthima might have been a typo in the original book. See: https://en.wikipedia.org/wiki/Iphthime
- Idothea is correct though Eidothea is better known. See: https://en.wikipedia.org/wiki/Eidothea_(Greek_myth)

The rest are trivial typo or missing spaces/punctuation fixes.