### PR TITLE
Fix typo in Book 10

### DIFF
--- a/src/epub/text/book-10.xhtml
+++ b/src/epub/text/book-10.xhtml
@@ -717,7 +717,7 @@
 				<br/>
 				<span>The sorceress, there met me on my way</span>
 				<br/>
-				<span>A youth; he seemed in manhood’s earJy prime,</span>
+				<span>A youth; he seemed in manhood’s early prime,</span>
 				<br/>
 				<span>When youth has most of grace. He took my hand</span>
 				<br/>


### PR DESCRIPTION
Currently, the phrase "he seemed in manhood's [earJy] prime" is used. This is a typo for "early". You can verify this by looking at the scan in [the Internet Archive source](https://archive.org/details/odysseyofhomer1899home1/page/n225/mode/2up), line 336.