### PR TITLE
Fixed multiple transcription errors

### DIFF
--- a/src/epub/text/book-15.xhtml
+++ b/src/epub/text/book-15.xhtml
@@ -171,7 +171,7 @@
 			<p>
 				<span>He spake, and quickly on her car of gold</span>
 				<br/>
-				<span>Appeared the Mom. Then Menelaus came,</span>
+				<span>Appeared the Morn. Then Menelaus came,</span>
 				<br/>
 				<span>The great in battle, from his couch beside</span>
 				<br/>

--- a/src/epub/text/book-17.xhtml
+++ b/src/epub/text/book-17.xhtml
@@ -303,7 +303,7 @@
 				<br/>
 				<span>Both from the king and his illustrious sons.</span>
 				<br/>
-				<span>Put he had heard, he said, from living man,</span>
+				<span>But he had heard, he said, from living man,</span>
 				<br/>
 				<span>No tidings of the much-enduring chief</span>
 				<br/>
@@ -1128,7 +1128,7 @@
 				<br/>
 				<span>Dared face the foe. On every side was death.</span>
 				<br/>
-				<span>The Egyptians hew r ed down many with the sword,</span>
+				<span>The Egyptians hewed down many with the sword,</span>
 				<br/>
 				<span>And some they led away alive to toil</span>
 				<br/>

--- a/src/epub/text/book-18.xhtml
+++ b/src/epub/text/book-18.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
 	<head>
-		<title>Book XVIII: Combat of Ulysses and Iris</title>
+		<title>Book XVIII: Combat of Ulysses and Irus</title>
 		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
 	</head>
@@ -13,7 +13,7 @@
 						<span epub:type="label">Book</span>
 						<span epub:type="ordinal z3998:roman">XVIII</span>
 					</h2>
-					<h3 epub:type="title">Combat of Ulysses and Iris</h3>
+					<h3 epub:type="title">Combat of Ulysses and Irus</h3>
 				</hgroup>
 				<p epub:type="bridgehead">Ulysses insulted by the beggar Irus⁠—Amusement of the suitors, who encourage the quarrel⁠—Victory of Ulysses in the combat with Irus⁠—Manoeuvre of Penelope to obtain presents from the suitors, and its success⁠—Ulysses insulted by Eurymachus⁠—His reply⁠—The cupbearer struck down by a footstool flung at Ulysses by Eurymachus.</p>
 			</header>
@@ -342,7 +342,7 @@
 				<br/>
 				<span>The mighty paunch before the victor, filled</span>
 				<br/>
-				<span>sWith blood and fat, and from the canister</span>
+				<span>With blood and fat, and from the canister</span>
 				<br/>
 				<span>Amphinomus brought forth two loaves, and raised</span>
 				<br/>

--- a/src/epub/text/book-19.xhtml
+++ b/src/epub/text/book-19.xhtml
@@ -29,7 +29,7 @@
 			<p>
 				<span>“Now is the time, Telemachus, to take</span>
 				<br/>
-				<span>The weapons thac are here, and store them up</span>
+				<span>The weapons that are here, and store them up</span>
 				<br/>
 				<span>In the inner rooms. Then, if the suitors ask</span>
 				<br/>
@@ -422,7 +422,7 @@
 				<br/>
 				<span>They caught me at my fraud, and chid me sore.</span>
 				<br/>
-				<span>sSo, though unwilling, I was forced to end</span>
+				<span>So, though unwilling, I was forced to end</span>
 				<br/>
 				<span>My task, and cannot longer now escape</span>
 				<br/>
@@ -1289,7 +1289,7 @@
 				<br/>
 				<span>The first was spilled. When she had bathed his feet</span>
 				<br/>
-				<span>And made them smooth with oil, Ulysses drew Close to the hearth his seat again, to take 6x5 The warmth, and with his tatters hid the scar. And thus the sage Penelope began:⁠—</span>
+				<span>And made them smooth with oil, Ulysses drew Close to the hearth his seat again, to take The warmth, and with his tatters hid the scar. And thus the sage Penelope began:⁠—</span>
 			</p>
 			<p>
 				<span>“Stranger, but little longer will I yet</span>
@@ -1383,7 +1383,7 @@
 				<span>And thus bespake me in a human voice:⁠—</span>
 			</p>
 			<p>
-				<span>“ ‘O daughter cf Icarius, the renowned!</span>
+				<span>“ ‘O daughter of Icarius, the renowned!</span>
 				<br/>
 				<span>Let not thy heart be troubled; this is not</span>
 				<br/>

--- a/src/epub/text/book-20.xhtml
+++ b/src/epub/text/book-20.xhtml
@@ -351,7 +351,7 @@
 			<p>
 				<span>“Dear nurse, have ye with honor fed and lodged</span>
 				<br/>
-				<span>Dur guest, or have ye suffered him to find</span>
+				<span>Our guest, or have ye suffered him to find</span>
 				<br/>
 				<span>A lodging where he might, without your care?</span>
 				<br/>
@@ -460,7 +460,7 @@
 				<br/>
 				<span>Two goatherds. In the echoing portico</span>
 				<br/>
-				<span>He bound his goats. He saw Ulvsses there,</span>
+				<span>He bound his goats. He saw Ulysses there,</span>
 				<br/>
 				<span>And thus accosted him with railing words:⁠—</span>
 			</p>

--- a/src/epub/text/book-21.xhtml
+++ b/src/epub/text/book-21.xhtml
@@ -437,7 +437,7 @@
 				<br/>
 				<span>And the swift shaft against the bow’s fair curve,</span>
 				<br/>
-				<span>He took again bis seat upon the throne</span>
+				<span>He took again his seat upon the throne</span>
 				<br/>
 				<span>From which he rose. Antinoüs then took up</span>
 				<br/>
@@ -719,7 +719,7 @@
 			<p>
 				<span>“Hearken, ye suitors of the illustrious queen,</span>
 				<br/>
-				<span>To what ray heart is prompting me to say;</span>
+				<span>To what my heart is prompting me to say;</span>
 				<br/>
 				<span>But chiefly to Eurymachus I make</span>
 				<br/>

--- a/src/epub/text/book-22.xhtml
+++ b/src/epub/text/book-22.xhtml
@@ -1143,7 +1143,7 @@
 				<br/>
 				<span>The herdsman and the swineherd to his side,</span>
 				<br/>
-				<span>And thus commanded them with wingea words:⁠—</span>
+				<span>And thus commanded them with winged words:⁠—</span>
 			</p>
 			<p>
 				<span>“Begin to carry forth the dead, and call</span>

--- a/src/epub/text/book-24.xhtml
+++ b/src/epub/text/book-24.xhtml
@@ -179,7 +179,7 @@
 				<br/>
 				<span>Of all the Argive host with eyes unwet,</span>
 				<br/>
-				<span>The Muses’ song so moved them. Seventeen day?</span>
+				<span>The Muses’ song so moved them. Seventeen days</span>
 				<br/>
 				<span>And nights we mourned thee⁠—both the immortal ones</span>
 				<br/>
@@ -982,7 +982,7 @@
 				<br/>
 				<span>And seats, and each put forth his hand and shared</span>
 				<br/>
-				<span>The banquet Now approached an aged man,</span>
+				<span>The banquet. Now approached an aged man,</span>
 				<br/>
 				<span>Dolius, attended by his sons, who came</span>
 				<br/>

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -71,7 +71,7 @@
 							<a href="text/book-17.xhtml">Book <span epub:type="z3998:roman">XVII</span>: Return of Ulysses to His Palace</a>
 						</li>
 						<li>
-							<a href="text/book-18.xhtml">Book <span epub:type="z3998:roman">XVIII</span>: Combat of Ulysses and Iris</a>
+							<a href="text/book-18.xhtml">Book <span epub:type="z3998:roman">XVIII</span>: Combat of Ulysses and Irus</a>
 						</li>
 						<li>
 							<a href="text/book-19.xhtml">Book <span epub:type="z3998:roman">XIX</span>: Ulysses Recognized by Eurycleia</a>


### PR DESCRIPTION
I verified these all with the [Google scans](https://www.google.com/books/edition/The_Odyssey_of_Homer/edgpAAAAYAAJ?gbpv=0). The only non trivial change is the alteration of the chapter title of Book 18. It was originally titled "Combat of Ulysses and Iris", but there is no character named "Iris". [Irus](https://en.wikipedia.org/wiki/Arnaeus) does exist and is mentioned many times in the text. Also, every piece of online discussion mentions "Irus" and not "Iris".