### PR TITLE
Fix typos and printer's error

### DIFF
--- a/src/epub/text/book-1.xhtml
+++ b/src/epub/text/book-1.xhtml
@@ -1081,7 +1081,7 @@
 			<p>
 				<span>He spake, but in his secret heart he knew</span>
 				<br/>
-				<span>The immortal goddess. Then the suitors turned.</span>
+				<span>The immortal goddess. Then the suitors turned,</span>
 				<br/>
 				<span>Delighted, to the dance and cheerful song,</span>
 				<br/>

--- a/src/epub/text/book-10.xhtml
+++ b/src/epub/text/book-10.xhtml
@@ -953,7 +953,7 @@
 				<br/>
 				<span>My thoughts were elsewhere; dark imaginings</span>
 				<br/>
-				<span>Were in my mind. When Circè marked my mood.</span>
+				<span>Were in my mind. When Circè marked my mood,</span>
 				<br/>
 				<span>As in a gloomy revery I sat,</span>
 				<br/>

--- a/src/epub/text/book-11.xhtml
+++ b/src/epub/text/book-11.xhtml
@@ -105,7 +105,7 @@
 				<span>Was wholly black, the best of all my flocks.</span>
 			</p>
 			<p>
-				<span>“When I had worshipped thus with praver and vows</span>
+				<span>“When I had worshipped thus with prayer and vows</span>
 				<br/>
 				<span>The nations of the dead, I took the sheep</span>
 				<br/>
@@ -698,7 +698,7 @@
 				<br/>
 				<span>Megara there, a daughter of the house</span>
 				<br/>
-				<span>Of laughty Creion. Her Amphitryon’s son,</span>
+				<span>Of haughty Creion. Her Amphitryon’s son,</span>
 				<br/>
 				<span>Unamable in strength, had made his wife.</span>
 			</p>

--- a/src/epub/text/book-13.xhtml
+++ b/src/epub/text/book-13.xhtml
@@ -831,7 +831,7 @@
 				<br/>
 				<span>Of Greece, were warring in the realm of Troy.</span>
 				<br/>
-				<span>But when we had o’erihrown the lofty town</span>
+				<span>But when we had o’erthrown the lofty town</span>
 				<br/>
 				<span>Of Priam, and embarked, and when some god</span>
 				<br/>

--- a/src/epub/text/book-15.xhtml
+++ b/src/epub/text/book-15.xhtml
@@ -665,7 +665,7 @@
 				<br/>
 				<span>Antiphates was father of a son,</span>
 				<br/>
-				<span>The brave O’icleus, and to him was born</span>
+				<span>The brave Oïcleus, and to him was born</span>
 				<br/>
 				<span>Amphioraüs, one of those whose voice</span>
 				<br/>
@@ -1411,7 +1411,7 @@
 			<p>
 				<span>Then turning to Piraeus he bespake</span>
 				<br/>
-				<span>That faithful follower thus: “Pirseus, son</span>
+				<span>That faithful follower thus: “Piraeus, son</span>
 				<br/>
 				<span>Of Clytius, thou who ever wert the first</span>
 				<br/>

--- a/src/epub/text/book-17.xhtml
+++ b/src/epub/text/book-17.xhtml
@@ -208,7 +208,7 @@
 				<span>At once, the gifts which Menelaus gave.”</span>
 			</p>
 			<p>
-				<span>“And then discreet Telemachus replied:</span>
+				<span>And then discreet Telemachus replied:</span>
 				<br/>
 				<span>“We know not yet, Piraeus, what may be</span>
 				<br/>

--- a/src/epub/text/book-17.xhtml
+++ b/src/epub/text/book-17.xhtml
@@ -1283,7 +1283,7 @@
 			<p>
 				<span>Then spake again the sage Penelope:</span>
 				<br/>
-				<span>“Mother, they all are hateful; everyone</span>
+				<span>“Mother, they all are hateful; every one</span>
 				<br/>
 				<span>Plots mischief, but Antinoüs most of all;</span>
 				<br/>

--- a/src/epub/text/book-17.xhtml
+++ b/src/epub/text/book-17.xhtml
@@ -323,7 +323,7 @@
 				<br/>
 				<span>What wish of mine had brought me to the town</span>
 				<br/>
-				<span>Of hallowed Lacedsemon. I replied,</span>
+				<span>Of hallowed Lacedaemon. I replied,</span>
 				<br/>
 				<span>And truly told him all, and everything</span>
 				<br/>
@@ -1057,7 +1057,7 @@
 				<br/>
 				<span>Gave somewhat to Ulysses, till his scrip</span>
 				<br/>
-				<span>Was filled with meat and bread Then as he went</span>
+				<span>Was filled with meat and bread. Then as he went</span>
 				<br/>
 				<span>Back to the threshold, there to feast on what</span>
 				<br/>

--- a/src/epub/text/book-18.xhtml
+++ b/src/epub/text/book-18.xhtml
@@ -965,7 +965,7 @@
 				<br/>
 				<span>And never dost thou work with willing hands,</span>
 				<br/>
-				<span>Bat dost prefer to roam the town and beg,</span>
+				<span>But dost prefer to roam the town and beg,</span>
 				<br/>
 				<span>Purveying for thy gluttonous appetite.”</span>
 			</p>

--- a/src/epub/text/book-21.xhtml
+++ b/src/epub/text/book-21.xhtml
@@ -62,7 +62,7 @@
 				<br/>
 				<span>To claim a debt from all the region round;</span>
 				<br/>
-				<span>For rovers from Messene to their ships</span>
+				<span>For rovers from Messenè to their ships</span>
 				<br/>
 				<span>Had driven and carried off from Ithaca</span>
 				<br/>
@@ -141,7 +141,7 @@
 				<br/>
 				<span>Its posts, and hung its shining doors, she loosed</span>
 				<br/>
-				<span>With a quick touch the thong that held the ring.</span>
+				<span>With a quick touch the thong that held the ring,</span>
 				<br/>
 				<span>Put in the key, and with a careful aim</span>
 				<br/>
@@ -922,7 +922,7 @@
 			<p>
 				<span>The queen, astonished, heard him and withdrew,</span>
 				<br/>
-				<span>But kept her son’s wise sayings in her heart</span>
+				<span>But kept her son’s wise sayings in her heart.</span>
 				<br/>
 				<span>And then ascending to her bower, among</span>
 				<br/>

--- a/src/epub/text/book-22.xhtml
+++ b/src/epub/text/book-22.xhtml
@@ -769,7 +769,7 @@
 				<br/>
 				<span>Meantime, Ulysses slew Damastor’s son</span>
 				<br/>
-				<span>With his long spear, in combat hand to hand</span>
+				<span>With his long spear, in combat hand to hand.</span>
 				<br/>
 				<span>Telemachus next smote Evenor’s son,</span>
 				<br/>

--- a/src/epub/text/book-23.xhtml
+++ b/src/epub/text/book-23.xhtml
@@ -727,7 +727,7 @@
 				<br/>
 				<span>Shall take me off in a serene old age,</span>
 				<br/>
-				<span>Amid a people prosperous and content</span>
+				<span>Amid a people prosperous and content.</span>
 				<br/>
 				<span>All this, the prophet said, will come to pass.”</span>
 			</p>

--- a/src/epub/text/book-24.xhtml
+++ b/src/epub/text/book-24.xhtml
@@ -1097,7 +1097,7 @@
 				<br/>
 				<span>He gathered in his ships and led abroad,</span>
 				<br/>
-				<span>And lost his gallant ships, and lost his men</span>
+				<span>And lost his gallant ships, and lost his men;</span>
 				<br/>
 				<span>And now, returning, he has put to death</span>
 				<br/>
@@ -1257,7 +1257,7 @@
 				<br/>
 				<span>Encouraged by his words, the goddess plunged</span>
 				<br/>
-				<span>Down from the summits of the Olympian mount</span>
+				<span>Down from the summits of the Olympian mount.</span>
 				<br/>
 				<span>Now when they all had feasted to the full,</span>
 				<br/>

--- a/src/epub/text/book-5.xhtml
+++ b/src/epub/text/book-5.xhtml
@@ -172,7 +172,7 @@
 				<br/>
 				<span>Was wafted o’er the isle the fragrant smoke</span>
 				<br/>
-				<span>Of cloven cedar, burning in the flame.</span>
+				<span>Of cloven cedar, burning in the flame,</span>
 				<br/>
 				<span>And cypress-wood. Meanwhile, in her recess,</span>
 				<br/>

--- a/src/epub/text/book-7.xhtml
+++ b/src/epub/text/book-7.xhtml
@@ -829,7 +829,7 @@
 				<br/>
 				<span>How much our galleys and our youths excel</span>
 				<br/>
-				<span>With bladed oars to stir the whirling brine”</span>
+				<span>With bladed oars to stir the whirling brine.”</span>
 			</p>
 			<p>
 				<span>So spake the king, and the great sufferer</span>


### PR DESCRIPTION
Hello!

The first commit is all OCR issues -- mostly missing/erroneous punctuation, but the occasional dropped accent or typo. These have been checked against the scans.

The second commit I'm pretty sure is a printer's error. The scan page is [here](https://babel.hathitrust.org/cgi/pt?id=nyp.33433082228606&seq=389), and the line in question is:

`“And then discreet Telemachus replied:`

I can't find a reason for the double quote to be there, as it's regular narration which doesn't use quotes throughout the rest of the work.

I did also have a question on an "every one" vs "everyone" that was modernized, but I didn't address it yet as I wasn't sure. The line (as-is in the current production) is

Then spake again the sage Penelope:
“Mother, they all are hateful; everyone
Plots mischief, but Antinoüs most of all;

"everyone" was originally "every one", and is referring to all of Penelope's suitors plotting mischief, not "everyone" (all people) plotting mischief.  I _think_ this should be back to "every one", but I've talked myself out of being confident about it.

 The scans are [here](https://babel.hathitrust.org/cgi/pt?id=nyp.33433082228606&seq=407) and in the repo [here](https://github.com/standardebooks/homer_the-odyssey_william-cullen-bryant/blob/27be615591c8bcff776f325782860b45af1b3152/src/epub/text/book-17.xhtml#L1286) for context.

